### PR TITLE
perf(serviceAccounts): allows syncing service accounts without resolv…

### DIFF
--- a/fiat-api/src/main/java/com/netflix/spinnaker/fiat/shared/FiatService.java
+++ b/fiat-api/src/main/java/com/netflix/spinnaker/fiat/shared/FiatService.java
@@ -82,6 +82,18 @@ public interface FiatService {
   long sync(@Body List<String> roles);
 
   /**
+   * Use to update a service account. As opposed to `sync`, this will not trigger a full sync for
+   * user role membership.
+   *
+   * @param serviceAccountId Name of the service account.
+   * @param roles The roles allowed for this service account.
+   * @return The number of non-anonymous users synced.
+   */
+  @POST("/roles/sync/serviceAccount/{serviceAccountId}")
+  long syncServiceAccount(
+      @Path("serviceAccountId") String serviceAccountId, @Body List<String> roles);
+
+  /**
    * @param userId The user being logged in
    * @param ignored ignored.
    * @return ignored.

--- a/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/permissions/DefaultPermissionsResolver.java
+++ b/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/permissions/DefaultPermissionsResolver.java
@@ -187,7 +187,8 @@ public class DefaultPermissionsResolver implements PermissionsResolver {
     return userToRoles;
   }
 
-  private Map<String, UserPermission> resolveResources(
+  @Override
+  public Map<String, UserPermission> resolveResources(
       @NonNull Map<String, Collection<Role>> userToRoles) {
     return userToRoles.entrySet().stream()
         .map(

--- a/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/permissions/PermissionsResolver.java
+++ b/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/permissions/PermissionsResolver.java
@@ -17,6 +17,7 @@
 package com.netflix.spinnaker.fiat.permissions;
 
 import com.netflix.spinnaker.fiat.model.UserPermission;
+import com.netflix.spinnaker.fiat.model.resources.Role;
 import java.util.Collection;
 import java.util.Map;
 
@@ -36,6 +37,11 @@ public interface PermissionsResolver {
   /** Resolves multiple user's permissions. Returned map is keyed by userId. */
   Map<String, UserPermission> resolve(Collection<ExternalUser> users)
       throws PermissionResolutionException;
+
+  /**
+   * Resolves multiple users resources without syncing group roles. Returned map is keyed by userId.
+   */
+  Map<String, UserPermission> resolveResources(Map<String, Collection<Role>> userToRoles);
 
   /** Clears resource cache: apps, service accounts,... */
   void clearCache();

--- a/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/roles/UserRolesSyncer.java
+++ b/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/roles/UserRolesSyncer.java
@@ -271,6 +271,10 @@ public class UserRolesSyncer {
     return count;
   }
 
+  public long syncServiceAccount(String serviceAccountId, List<String> roles) {
+    return syncStrategy.syncServiceAccount(serviceAccountId, roles);
+  }
+
   private static String metricName(String name) {
     return "fiat.userRoles." + name;
   }

--- a/fiat-roles/src/test/groovy/com/netflix/spinnaker/fiat/roles/UserRolesSyncerSpec.groovy
+++ b/fiat-roles/src/test/groovy/com/netflix/spinnaker/fiat/roles/UserRolesSyncerSpec.groovy
@@ -28,6 +28,7 @@ import com.netflix.spinnaker.fiat.model.resources.Application
 import com.netflix.spinnaker.fiat.model.resources.BuildService
 import com.netflix.spinnaker.fiat.model.resources.Role
 import com.netflix.spinnaker.fiat.model.resources.ServiceAccount
+import com.netflix.spinnaker.fiat.permissions.ExternalUser
 import com.netflix.spinnaker.fiat.permissions.PermissionsResolver
 import com.netflix.spinnaker.fiat.permissions.RedisPermissionRepositoryConfigProps
 import com.netflix.spinnaker.fiat.permissions.RedisPermissionsRepository
@@ -246,6 +247,93 @@ class UserRolesSyncerSpec extends Specification {
     discoveryStatusEnabled                         || shouldAcquireLock
     true                                           || true
     false                                          || false
+  }
+
+  @Unroll
+  def "syncServiceAccounts adds service accounts and updates relevant users"() {
+    setup:
+    def extRoleA = new Role("extrolea").setSource(Role.Source.EXTERNAL)
+    def extRoleB = new Role("extroleb").setSource(Role.Source.EXTERNAL)
+    def extRoleC = new Role("extrolec").setSource(Role.Source.EXTERNAL)
+    def abcResource = new ServiceAccount().setName("abc@managed-service-account").setMemberOf(["extroleb"])
+
+    def user1 = new UserPermission()
+            .setId("user1")
+            .setAccounts([new Account().setName("account1")] as Set)
+            .setRoles([extRoleA, extRoleC] as Set)
+    def user2 = new UserPermission()
+            .setId("user2")
+            .setAccounts([new Account().setName("account2")] as Set)
+            .setRoles([extRoleA] as Set)
+            .addResources([abcResource])
+    def user3 = new UserPermission()
+            .setId("user3")
+            .setAccounts([new Account().setName("account3")] as Set)
+            .setRoles([extRoleB, extRoleC] as Set)
+            .addResources([abcResource])
+    def unrestrictedUser = new UserPermission()
+            .setId(UnrestrictedResourceConfig.UNRESTRICTED_USERNAME)
+            .setAccounts([new Account().setName("unrestrictedAccount")] as Set)
+    def abcServiceAcct = new UserPermission()
+            .setId("abc@managed-service-account")
+            .setRoles([extRoleB, extRoleC] as Set)
+            .addResources([abcResource])
+    def newServiceAccountResource = new ServiceAccount().setName("new@managed-service-account").setMemberOf([extRoleB.name, extRoleC.name])
+    def newServiceAcct = new UserPermission()
+            .setId("new@managed-service-account")
+            .setRoles([extRoleB, extRoleC] as Set)
+            .addResources([abcResource, newServiceAccountResource])
+
+    def allUsers = [user1, user2, user3, abcServiceAcct, newServiceAcct, unrestrictedUser]
+    (allUsers - [newServiceAcct]).forEach({it -> repo.put(it)})
+
+    def serviceAccountProvider = Mock(ResourceProvider)
+    def permissionsResolver = Mock(PermissionsResolver) { resolver ->
+      resolver.resolveAndMerge(new ExternalUser().setId("new@managed-service-account").setExternalRoles([extRoleB, extRoleC])) >> newServiceAcct
+      Map<String, Collection<Role>> userRoles = (allUsers - [user1, user2, unrestrictedUser]).collectEntries {[it.id, it.roles]}
+      resolver.resolveResources(userRoles) >>
+              (allUsers - [user1, user2, unrestrictedUser]).collectEntries { [it.id, it.addResources([newServiceAccountResource])]}
+    }
+
+    def lockManager = Mock(LockManager) {
+      _ * acquireLock() >> { LockManager.LockOptions lockOptions, Callable onLockAcquiredCallback ->
+        onLockAcquiredCallback.call()
+      }
+    }
+
+    @Subject
+    def syncer = new UserRolesSyncer(
+            new DiscoveryStatusListener(false),
+            registry,
+            lockManager,
+            new UserRolesSyncStrategy.DefaultSynchronizationStrategy(
+                    new Synchronizer(
+                            new AlwaysUpHealthIndicator(),
+                            permissionsResolver,
+                            repo,
+                            serviceAccountProvider,
+                            registry,
+                            1,
+                            1)),
+            1,
+            1,
+            1,
+            ""
+    )
+
+    expect:
+    repo.getAllByRoles([extRoleB.name, extRoleC.name]) == (allUsers - [user2, newServiceAcct]).collectEntries { [ it.id, it.roles]}
+
+    when:
+    syncer.syncServiceAccount("new@managed-service-account", [extRoleB.name, extRoleC.name])
+
+    then:
+    permissionsResolver.resolveUnrestrictedUser() >> unrestrictedUser
+
+    expect:
+    repo.getAllById() == allUsers.collectEntries { [ it.id, it.roles]}
+    [user1, user2, user3, newServiceAcct, abcServiceAcct, unrestrictedUser]
+            .forEach({ it -> repo.get(it.getId()).get() == it.merge(unrestrictedUser) })
   }
 
   class AlwaysUpHealthIndicator extends ResourceProvidersHealthIndicator {

--- a/fiat-web/src/main/java/com/netflix/spinnaker/fiat/controllers/RolesController.java
+++ b/fiat-web/src/main/java/com/netflix/spinnaker/fiat/controllers/RolesController.java
@@ -112,4 +112,14 @@ public class RolesController {
     }
     return count;
   }
+
+  @RequestMapping(value = "/sync/serviceAccount/{serviceAccountId:.+}", method = RequestMethod.POST)
+  public long syncServiceAccount(
+      @PathVariable String serviceAccountId, @RequestBody List<String> specificRoles) {
+    log.info(
+        "Service Account {} sync invoked by web request with roles: {}",
+        serviceAccountId,
+        specificRoles);
+    return syncer.syncServiceAccount(serviceAccountId, specificRoles);
+  }
 }


### PR DESCRIPTION
…ing user roles (#961)

* perf(serviceAccounts): new endpoint which allows syncing service accounts without a full group membership sync for all related users

* perf(serviceAccounts): lint

We prefer small, well tested pull requests.

Please refer to [Contributing to Spinnaker](https://spinnaker.io/community/contributing/).

When filling out a pull request, please consider the following:

* Follow the commit message conventions [found here](https://spinnaker.io/community/contributing/submitting/).
* Provide a descriptive summary for your changes.
* If it fixes a bug or resolves a feature request, be sure to link to that issue.
* Add inline code comments to changes that might not be obvious.
* Squash your commits as you keep adding changes.
* Add a comment to @spinnaker/reviewers for review if your issue has been outstanding for more than 3 days.

Note that we are unlikely to accept pull requests that add features without prior discussion. The best way to propose a feature is to open an issue first and discuss your ideas there before implementing them.
